### PR TITLE
fix: bee compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
       - '**'
 
 env:
-  BEE_VERSION: '1.0.0-2572fa48'
+  BEE_VERSION: '1.1.0'
   BLOCKCHAIN_VERSION: '1.2.0'
   BEE_ENV_PREFIX: 'swarm-test'
   BEE_IMAGE_PREFIX: 'docker.pkg.github.com/ethersphere/bee-factory'

--- a/README.md
+++ b/README.md
@@ -112,6 +112,20 @@ The following describes the format of a node binary format.
 └──────────────────────────────────────────────────────────────┘
 ```
 
+# Testing
+
+The testing needs running Bee client node for integration testing.
+You can set `BEE_POSTAGE` environment variable with a valid Postage batch or the test will create one for you.
+
+The default value of the Bee Debug API endpoint is `http://localhost:1635`. 
+If your address diverges from that, please, set `BEE_DEBUG_API_URL` system environment variable with yours.
+
+To run test execute
+
+```sh
+npm run test
+```
+
 ## Maintainers
 
 - [nugaon](https://github.com/nugaon)

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,15 +3,15 @@
  * For a detailed explanation regarding each configuration property and type check, visit:
  * https://jestjs.io/docs/en/configuration.html
  */
-import { Bee } from '@ethersphere/bee-js'
+import { BeeDebug } from '@ethersphere/bee-js'
 import type { Config } from '@jest/types'
 
 export default async (): Promise<Config.InitialOptions> => {
   if (!process.env.BEE_POSTAGE) {
     try {
       console.log('Creating postage stamps...')
-      const beeUrl = process.env.BEE_API_URL || 'http://localhost:1633'
-      const bee = new Bee(beeUrl)
+      const beeDebugUrl = process.env.BEE_DEBUG_API_URL || 'http://localhost:1635'
+      const bee = new BeeDebug(beeDebugUrl)
       process.env.BEE_POSTAGE = await bee.createPostageBatch('1', 20)
       console.log('Queen stamp: ', process.env.BEE_POSTAGE)
       // sleep for 11 seconds (10 blocks with ganache block time = 1s)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1788,9 +1788,9 @@
       }
     },
     "node_modules/@ethersphere/bee-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@ethersphere/bee-js/-/bee-js-1.0.0.tgz",
-      "integrity": "sha512-u+TnKf0loAQba7AfZ54kXIEWjNdqVMUR6NXwINhHa2IdoD2b52rcuP96eMImlUm4tEJkxi2yAS+lcIZ2U9/1Vw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@ethersphere/bee-js/-/bee-js-1.2.1.tgz",
+      "integrity": "sha512-Z1lh016EB8bxTNHUDXCDEcJN8IrPaz+vlIz89oscJF9q3Xuevmo/QCn7fQ0dqrppB8Motz7gjPteFJk5glsNGQ==",
       "dev": true,
       "dependencies": {
         "axios": "^0.21.1",
@@ -1798,10 +1798,10 @@
         "isomorphic-ws": "^4.0.1",
         "js-sha3": "^0.8.0",
         "tar-js": "^0.3.0",
-        "ws": "^7.4.4"
+        "ws": "^7.5.0"
       },
       "engines": {
-        "bee": "1.0.0-2572fa48",
+        "bee": "1.1.0-80cdea19",
         "node": ">=12.0.0",
         "npm": ">=6.0.0"
       }
@@ -9153,9 +9153,9 @@
       }
     },
     "@ethersphere/bee-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@ethersphere/bee-js/-/bee-js-1.0.0.tgz",
-      "integrity": "sha512-u+TnKf0loAQba7AfZ54kXIEWjNdqVMUR6NXwINhHa2IdoD2b52rcuP96eMImlUm4tEJkxi2yAS+lcIZ2U9/1Vw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@ethersphere/bee-js/-/bee-js-1.2.1.tgz",
+      "integrity": "sha512-Z1lh016EB8bxTNHUDXCDEcJN8IrPaz+vlIz89oscJF9q3Xuevmo/QCn7fQ0dqrppB8Motz7gjPteFJk5glsNGQ==",
       "dev": true,
       "requires": {
         "axios": "^0.21.1",
@@ -9163,7 +9163,7 @@
         "isomorphic-ws": "^4.0.1",
         "js-sha3": "^0.8.0",
         "tar-js": "^0.3.0",
-        "ws": "^7.4.4"
+        "ws": "^7.5.0"
       }
     },
     "@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Mantaray data structure in JS",
   "main": "dist/index.min.js",
-  "types": "dist/src/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "prepare": "rimraf dist && npm run compile:types && npm run compile --env mode=production",
     "compile": "webpack --progress --env target=node",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepare": "rimraf dist && npm run compile:types && npm run compile --env mode=production",
     "compile": "webpack --progress --env target=node",
     "compile:types": "tsc --emitDeclarationOnly --declaration --skipLibCheck",
-    "dev": "npm run compile:node -- --watch --env mode=development",
+    "dev": "npm run compile -- --watch --env mode=development",
     "lint": "eslint --fix \"src/**/*.ts\" && prettier --write \"src/**/*.ts\"",
     "lint:check": "eslint \"src/**/*.ts\" && prettier --check \"src/**/*.ts\"",
     "check:types": "tsc --project tsconfig.json --skipLibCheck",

--- a/src/node.ts
+++ b/src/node.ts
@@ -683,12 +683,36 @@ export async function loadAllNodes(storageLoader: StorageLoader, node: MantarayN
  * @throws Error if the two nodes properties are not equal recursively
  */
 export const equalNodes = (a: MantarayNode, b: MantarayNode, accumulatedPrefix = ''): void | never => {
+  // node type comparisation
   if (a.getType !== b.getType) {
     throw Error(`Nodes do not have same type at prefix "${accumulatedPrefix}"\na: ${a.getType} <-> b: ${b.getType}`)
   }
 
+  // node metadata comparisation
+  if (!a.getMetadata !== !b.getMetadata) {
+    throw Error(`One of the nodes do not have metadata defined. \n a: ${a.getMetadata} \n b: ${b.getMetadata}`)
+  } else if (a.getMetadata && b.getMetadata) {
+    let aMetadata, bMetadata: string
+    try {
+      aMetadata = JSON.stringify(a.getMetadata)
+      bMetadata = JSON.stringify(b.getMetadata)
+    } catch (e) {
+      throw Error(`Either of the nodes has invalid JSON metadata. \n a: ${a.getMetadata} \n b: ${b.getMetadata}`)
+    }
+
+    if (aMetadata !== bMetadata) {
+      throw Error(`The node's metadata are different. a: ${aMetadata} \n b: ${bMetadata}`)
+    }
+  }
+
+  // node entry comparisation
+  if (a.getEntry === b.getEntry) {
+    throw Error(`Nodes do not have same entries. \n a: ${a.getEntry} \n b: ${a.getEntry}`)
+  }
+
   if (!a.forks) return
 
+  // node fork comparisation
   const aKeys = Object.keys(a.forks)
 
   if (!b.forks || aKeys.length !== Object.keys(b.forks).length) {

--- a/src/node.ts
+++ b/src/node.ts
@@ -381,8 +381,7 @@ export class MantarayNode {
       newNode = new MantarayNode()
       newNode.setObfuscationKey = this.obfuscationKey || (new Uint8Array(32) as Bytes<32>)
 
-      // TODO: change it on Bee-side: code below does not do anything 
-      // fork.node.updateWithPathSeparator(restPath)
+      fork.node.updateWithPathSeparator(restPath)
       newNode.forks = {}
       newNode.forks[restPath[0]] = new MantarayFork(restPath, fork.node)
       newNode.makeEdge()

--- a/src/node.ts
+++ b/src/node.ts
@@ -210,7 +210,7 @@ export class MantarayNode {
     // TODO: when the mantaray node is a pointer by its metadata then
     // the node has to be with `value` type even though it has zero address
     // should get info why is `withMetadata` as type is not enough
-    if (metadata['website-index-document']) {
+    if (metadata['website-index-document'] || metadata['website-error-document']) {
       this.makeValue()
     }
     this.makeDirty()

--- a/src/node.ts
+++ b/src/node.ts
@@ -216,15 +216,11 @@ export class MantarayNode {
     this.makeDirty()
   }
 
-  public get getObfuscationKey(): Bytes<32> {
-    if (!this.obfuscationKey) throw PropertyIsUndefined
-
+  public get getObfuscationKey(): Bytes<32> | undefined {
     return this.obfuscationKey
   }
 
-  public get getEntry(): Reference {
-    if (!this.entry) throw PropertyIsUndefined
-
+  public get getEntry(): Reference | undefined {
     return this.entry
   }
 
@@ -232,9 +228,7 @@ export class MantarayNode {
     return this.contentAddress
   }
 
-  public get getMetadata(): MetadataMapping {
-    if (!this.metadata) throw PropertyIsUndefined
-
+  public get getMetadata(): MetadataMapping | undefined {
     return this.metadata
   }
 
@@ -675,7 +669,7 @@ export async function loadAllNodes(storageLoader: StorageLoader, node: MantarayN
   if (!node.forks) return
 
   for (const fork of Object.values(node.forks)) {
-    await fork.node.load(storageLoader, fork.node.getEntry)
+    if (fork.node.getEntry) await fork.node.load(storageLoader, fork.node.getEntry)
     await loadAllNodes(storageLoader, fork.node)
   }
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -51,6 +51,7 @@ it('should construct manifests of testpage folder', async () => {
   const data = await beeTestPageManifestData()
   const node = new MantarayNode()
   node.deserialize(data)
+  await loadAllNodes(loadFunction, node)
 
   const testPage = join(__dirname, 'testpage')
   const indexHtmlBytes = FS.readFileSync(join(testPage, 'index.html'))
@@ -76,7 +77,7 @@ it('should construct manifests of testpage folder', async () => {
     'Content-Type': 'image/png',
     Filename: 'icon.png',
   })
-  iNode.addFork(utf8ToBytes('/'), hexToBytes(indexReference), {
+  iNode.addFork(utf8ToBytes('/'), new Uint8Array(32) as Reference, {
     'website-index-document': 'index.html',
   })
   const iNodeRef = await iNode.save(saveFunction)
@@ -85,7 +86,10 @@ it('should construct manifests of testpage folder', async () => {
   const iNodeAgain = new MantarayNode()
   iNodeAgain.deserialize(marshal)
   await loadAllNodes(loadFunction, iNodeAgain)
+  // check after serialization the object is same
   expect(iNode).toBeEqualNode(iNodeAgain)
+  // check bee manifest is equal with the constructed one.
+  expect(iNode).toBeEqualNode(node)
   // eslint-disable-next-line no-console
   console.log('Constructed root manifest hash', Utils.Hex.bytesToHex(iNodeRef))
 })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -70,7 +70,7 @@ it('should construct manifests of testpage folder', async () => {
     Filename: 'index.html',
   })
   iNode.addFork(utf8ToBytes('img/icon.png.txt'), hexToBytes(haliReference), {
-    'Content-Type': 'text/plain',
+    'Content-Type': '', // FIXME: The bee node assigns empty string to Content Type in this case
     Filename: 'icon.png.txt',
   })
   iNode.addFork(utf8ToBytes('img/icon.png'), hexToBytes(imageReference), {


### PR DESCRIPTION
There were some difference between the `mantaray-js` and the `Bee client` mantaray construction related to the mantaray node's types.
1. at `withPathSeparator` node type updates, the bee node ignores the first byte of the path
2. a node with `entry` of full zeros can have `value` type.

All cases need clarification, because these considerations are a little bit vague for me. Maybe @zelig @acud ?

Anyway, this PR tries to eradicate these differences, with the followings:
1. `mantaray-js` also ignores the first byte of `path` as well on `withPathSeparator` update
2. if metadata with `website-index-document` key is presented, the node will have type `value`. It is because the the zero value `entry` only occured as a problem at this use-case.

Additionally, because the `mantaray-js` uses slightly different logic, I made a fix at `special case on edge split` which seemed wrong in both codes and it somehow made the full compatiblity with `Bee` mantarays, despite this flaw remained the same on Bee-side...

Closes #12, Closes #13