### PR TITLE
test: fix content-type for .txt file

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -70,7 +70,7 @@ it('should construct manifests of testpage folder', async () => {
     Filename: 'index.html',
   })
   iNode.addFork(utf8ToBytes('img/icon.png.txt'), hexToBytes(textReference), {
-    'Content-Type': '', // FIXME: The bee node assigns empty string to Content Type in this case
+    'Content-Type': 'text/plain; charset=utf-8',
     Filename: 'icon.png.txt',
   })
   iNode.addFork(utf8ToBytes('img/icon.png'), hexToBytes(imageReference), {


### PR DESCRIPTION
When testing with Bee 1.7.0 one test fails because the reported content-type for .txt files does not match what is expected in the test. Most likely this has been a change in Bee, more specifically in the `mime` package.

With the proposed change the tests run without errors.